### PR TITLE
add repository field so it appears on npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "author": "Jonathan Giroux <giroux.jo@gmail.com>",
   "license": "MIT",
+  "repository": "KoltesDigital/lerna-dependency-graph",
   "description": "Outputs dependencies in a Lerna monorepo using Graphviz.",
   "keywords": [
     "graphviz",


### PR DESCRIPTION
Currently, right sidebar of npm package https://www.npmjs.com/package/lerna-dependency-graph is missing "homepage" link because it's not in package.json. Let's add it!